### PR TITLE
Deepfreeze

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - 0.11
   - 0.12
+  - 4
+  - 5
+  - 6

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ poster("http://example.com/query", body, function (err, content) {
 ### Allowed behavior options
 
 * `freeze`: (default:`true`). When this option is set to false it will not freeze the response so it can be modified. ("use strict" is needed)
+* `deepFreeze`: (default:`false`). When this option is set to true it will freeze the response _recursively_ so that it or any objects it contains can't be modified. ("use strict" is needed)
 * `cache`: (default: `an instance of AsyncCache`) (https://github.com/ExpressenAB/exp-asynccache). To disable caching set `{cache: null}`
 * `cacheKeyFn`: (default: caches on the url + sha1 of the body) An optional formatting function for finding the cache-key. One might, for example, want to cache on an url with the get params stripped.
 * `cacheValueFn`: (default: caches the response body) An optional function for change what will be returned and cached from fetch.
@@ -87,6 +88,10 @@ poster("http://example.com/query", body, function (err, content) {
 * `followRedirect`: (default: true), should fetch follow redirects (and cache the redirect chain)
 * `clone`: (default: true), should fetch clone objects before handing them from the cache.
 * `httpMethod`: (default: `"GET"`), the HTTP-method that should be used to make requests. 
+
+The difference between `freeze` and `deepFreeze` is that `deepFreeze` walks the object graph and freezes any
+child objects in the retrieved data. `freeze` only freezes the root object but still allows modifications
+to nested objects. `deepFreeze` will be slower since it is recursive.
 
 #### CacheKeyFn
 

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function buildFetch(behavior) {
 
   // Options
   var freeze = true;
+  var deepFreeze = false;
   var cache = new AsyncCache(initCache({age: 60}));
   var cacheKeyFn = behavior.cacheKeyFn || calculateCacheKey;
   var cacheValueFn = behavior.cacheValueFn || passThrough;
@@ -53,6 +54,10 @@ function buildFetch(behavior) {
 
   if (behavior.hasOwnProperty("freeze")) {
     freeze = !!behavior.freeze;
+  }
+
+  if (behavior.hasOwnProperty("deepFreeze")) {
+    deepFreeze = !!behavior.deepFreeze;
   }
 
   if (behavior.hasOwnProperty("followRedirect")) {
@@ -97,11 +102,31 @@ function buildFetch(behavior) {
     return resolvedCallback(error, cacheValueFn(undefined, res.headers, res.statusCode), errorAge);
   }
 
+  function deepFreezeObj(obj) {
+    var propNames = Object.getOwnPropertyNames(obj);
+
+    propNames.forEach((name) => {
+      var prop = obj[name];
+
+      if (typeof prop === "object" && prop !== null) {
+        deepFreezeObj(prop);
+      }
+    });
+
+    return Object.freeze(obj);
+  }
+
   function handleSuccess(url, cacheKey, res, content, resolvedCallback) {
     var maxAge = maxAgeFn(getMaxAge(res.headers["cache-control"]), cacheKey, res, content);
-    if (freeze && typeof content === "object") {
+
+    var contentType = typeof content;
+
+    if (deepFreeze && contentType === "object") {
+      deepFreezeObj(content);
+    } else if (freeze && contentType === "object") {
       Object.freeze(content);
     }
+
     if (onSuccess) {
       onSuccess(url, cacheKey, res, content);
     }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function buildFetch(behavior) {
   function deepFreezeObj(obj) {
     var propNames = Object.getOwnPropertyNames(obj);
 
-    propNames.forEach((name) => {
+    propNames.forEach(function(name) {
       var prop = obj[name];
 
       if (typeof prop === "object" && prop !== null) {

--- a/test/fetchingTest.js
+++ b/test/fetchingTest.js
@@ -95,22 +95,24 @@ describe("fetch", function () {
 
     it("should not freeze content if freeze is set to false", function (done) {
       var localFetch = fetchBuilder({freeze:false, clone: false}).fetch;
-      fake.get(path).times(2).reply(200, {some: "content", child: { some: "child-content" }}, {"cache-control": "no-cache"});
-      fetch(host + path, function (err, content) {
-        Object.isFrozen(content).should.be.true;
+      fake.get(path).reply(200, {some: "content", child: { some: "child-content" }}, {"cache-control": "no-cache"});
+      localFetch(host + path, function (err, content) {
+        Object.isFrozen(content).should.be.false;
         Object.isFrozen(content.child).should.be.false;
-
-        should.throw(function () {
-          content.prop1 = true;
-        }, TypeError);
-        localFetch(host + path, function (err, content) {
-          should.not.throw(function () {
-            content.prop1 = true;
-          }, TypeError);
-          done(err);
-        });
+        done(err);
       });
     });
+
+    it("should freeze the result root but not descendants by default", function (done) {
+      var localFetch = fetchBuilder({clone: false}).fetch;
+      fake.get(path).reply(200, {some: "content", child: { some: "child-content" }}, {"cache-control": "no-cache"});
+      localFetch(host + path, function (err, content) {
+        Object.isFrozen(content).should.be.true;
+        Object.isFrozen(content.child).should.be.false;
+        done(err);
+      });
+    });
+
 
     it("should freeze objects recursively if deepFreeze is set to true", function (done) {
       var localFetch = fetchBuilder({deepFreeze:true, clone: false}).fetch;

--- a/test/fetchingTest.js
+++ b/test/fetchingTest.js
@@ -95,8 +95,11 @@ describe("fetch", function () {
 
     it("should not freeze content if freeze is set to false", function (done) {
       var localFetch = fetchBuilder({freeze:false, clone: false}).fetch;
-      fake.get(path).times(2).reply(200, {some: "content"}, {"cache-control": "no-cache"});
+      fake.get(path).times(2).reply(200, {some: "content", child: { some: "child-content" }}, {"cache-control": "no-cache"});
       fetch(host + path, function (err, content) {
+        Object.isFrozen(content).should.be.true;
+        Object.isFrozen(content.child).should.be.false;
+
         should.throw(function () {
           content.prop1 = true;
         }, TypeError);
@@ -106,6 +109,16 @@ describe("fetch", function () {
           }, TypeError);
           done(err);
         });
+      });
+    });
+
+    it("should freeze objects recursively if deepFreeze is set to true", function (done) {
+      var localFetch = fetchBuilder({deepFreeze:true, clone: false}).fetch;
+      fake.get(path).reply(200, {some: "content", child: { some: "child-content" }}, {"cache-control": "no-cache"});
+      localFetch(host + path, function (err, content) {
+        Object.isFrozen(content).should.be.true;
+        Object.isFrozen(content.child).should.be.true;
+        done(err);
       });
     });
   });


### PR DESCRIPTION
"Deep freeze" objects, i.e. freeze them recursively. The original `freeze` behahvior only freezes the root of the resulting object graph.

`deepFreeze` can be set as a behavior and the original `freeze` behavior is untouched due to potential performance implications of the `deepFreeze` behavior.