### PR TITLE
Add feature to have a global header set on all requests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function buildFetch(behavior) {
   var httpMethod = (behavior.httpMethod || "GET").toUpperCase();
   var timeout = behavior.timeout || 20000;
   var stats = {calls: 0, misses: 0};
+  var globalHeaders = behavior.headers || {};
 
   function defaultRequestTimeFn(requestOptions, took) {
     logger.debug("fetching %s: %s took %sms", requestOptions.method, requestOptions.url, took);
@@ -214,14 +215,11 @@ function buildFetch(behavior) {
   return {
     fetch: function (options, optionalBody, resultCallback) {
       var url = options;
-      var headers = {};
+      var headers = Object.assign({}, globalHeaders, options.headers);
       var explicitTimeout = null;
       if (typeof options === "object") {
         if (options.url) {
           url = options.url;
-        }
-        if (options.headers) {
-          headers = options.headers;
         }
         if (options.timeout) {
           explicitTimeout = options.timeout;

--- a/test/fetchingTest.js
+++ b/test/fetchingTest.js
@@ -579,7 +579,6 @@ describe("fetch", function () {
         .matchHeader("User-Agent", "request")
         .matchHeader("X-Test", "test")
         .reply(200, {some: "content"}, {"cache-control": "no-cache"});
-
       fetch(options, function (err, body) {
         body.should.eql({some: "content"});
         done(err);
@@ -590,6 +589,7 @@ describe("fetch", function () {
     it("should be able to pass on request headers in promises", function (done) {
       fake.get(path)
         .matchHeader("User-Agent", "request")
+        .matchHeader("X-Test", "test")
         .reply(200, {some: "content"}, {"cache-control": "no-cache"});
       fetch(options).then(function (body) {
         body.should.eql({some: "content"});
@@ -602,6 +602,7 @@ describe("fetch", function () {
         .reply(301, {}, {"cache-control": "no-cache", "location": "http://example.com/testing321"});
       fake.get("/testing321")
         .matchHeader("User-Agent", "request")
+        .matchHeader("X-Test", "test")
         .reply(200, {some: "content"}, {"cache-control": "no-cache"});
       fetch(options, function (err, body) {
         body.should.eql({some: "content"});
@@ -614,9 +615,10 @@ describe("fetch", function () {
         .matchHeader("User-Agent", "local-request")
         .reply(200, {some: "content"}, {"cache-control": "no-cache"});
       options.headers = { "User-Agent" : "local-request"};
-      fetch(options).then(function (body) {
+      fetch(options, function (err, body) {
+        console.log(err);
         body.should.eql({some: "content"});
-        done();
+        done(err);
       });
     });
   });

--- a/test/fetchingTest.js
+++ b/test/fetchingTest.js
@@ -43,7 +43,7 @@ describe("fetch", function () {
     it("should be able to pass on request headers", function (done) {
       fake.get(path).matchHeader("User-Agent", "request").reply(200, {some: "content"}, {"cache-control": "no-cache"});
       var options = {
-        url: host + path, 
+        url: host + path,
         headers: { "User-Agent": "request"}
       }
       fetch(options, function (err, body) {
@@ -55,7 +55,7 @@ describe("fetch", function () {
     it("should be able to pass on request headers in promises", function (done) {
       fake.get(path).matchHeader("User-Agent", "request").reply(200, {some: "content"}, {"cache-control": "no-cache"});
       var options = {
-        url: host + path, 
+        url: host + path,
         headers: { "User-Agent": "request"}
       }
       fetch(options).then(function (body) {
@@ -68,7 +68,7 @@ describe("fetch", function () {
       fake.get(path).reply(301, {}, {"cache-control": "no-cache", "location": "http://example.com/testing321"});
       fake.get("/testing321").matchHeader("User-Agent", "request").reply(200, {some: "content"}, {"cache-control": "no-cache"});
       var options = {
-        url: host + path, 
+        url: host + path,
         headers: { "User-Agent": "request"}
       }
       fetch(options, function (err, body) {
@@ -559,6 +559,63 @@ describe("fetch", function () {
       fetch({url: host + path, timeout: 1}).catch(function (err) {
         should.exist(err);
         err.message.should.include("ESOCKETTIMEDOUT");
+        done();
+      });
+    });
+  });
+
+  describe("Global header", function() {
+    const fetch = fetchBuilder({
+        headers: { "User-Agent": "request"}
+    }).fetch;
+
+    const options = {
+      url: host + path,
+      headers: {"X-Test": "test"}
+    };
+
+    it("should pass through global headers and local headers", function(done) {
+      fake.get(path)
+        .matchHeader("User-Agent", "request")
+        .matchHeader("X-Test", "test")
+        .reply(200, {some: "content"}, {"cache-control": "no-cache"});
+
+      fetch(options, function (err, body) {
+        body.should.eql({some: "content"});
+        done(err);
+      });
+    });
+
+
+    it("should be able to pass on request headers in promises", function (done) {
+      fake.get(path)
+        .matchHeader("User-Agent", "request")
+        .reply(200, {some: "content"}, {"cache-control": "no-cache"});
+      fetch(options).then(function (body) {
+        body.should.eql({some: "content"});
+        done();
+      });
+    });
+
+    it("should pass request headers on to redirects", function (done) {
+      fake.get(path)
+        .reply(301, {}, {"cache-control": "no-cache", "location": "http://example.com/testing321"});
+      fake.get("/testing321")
+        .matchHeader("User-Agent", "request")
+        .reply(200, {some: "content"}, {"cache-control": "no-cache"});
+      fetch(options, function (err, body) {
+        body.should.eql({some: "content"});
+        done(err);
+      });
+    });
+
+    it("should make sure local headers take precedence over global", function (done) {
+      fake.get(path)
+        .matchHeader("User-Agent", "local-request")
+        .reply(200, {some: "content"}, {"cache-control": "no-cache"});
+      options.headers = { "User-Agent" : "local-request"};
+      fetch(options).then(function (body) {
+        body.should.eql({some: "content"});
         done();
       });
     });


### PR DESCRIPTION
This patch adds a feature to set a header object in the buildFetch
step. This sets the header for _all_ requests if it is not overriden
in the options object for the fetch.